### PR TITLE
Wire up coqchk error handling in the minimizer runner

### DIFF
--- a/.github/workflows/test-wrapper.yml
+++ b/.github/workflows/test-wrapper.yml
@@ -1,0 +1,18 @@
+name: test-wrapper
+
+# Unit tests for the coqc/coqchk wrapper logic (coqbot-config.sh +
+# coqchk-as-coqc.sh).  These use fake coqc/coqchk stubs, so they run quickly on
+# a plain Ubuntu runner without installing Coq/Rocq.
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test-wrapper:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run coqchk wrapper tests
+        run: ./test/test-coqchk-wrapper.sh

--- a/coqbot-config.sh
+++ b/coqbot-config.sh
@@ -117,9 +117,10 @@ if [[ "\$1" != "c" ]] && [[ "\$1" != "compile" ]] && [[ "\$1" != "check" ]]; the
 fi
 EOF
         fi
-        if [[ "$file" != *coqchk* ]] && [[ "$file" != *rocqchk* ]]; then
+        if [[ "$file" == *coqchk* ]] || [[ "$file" == *rocqchk* ]]; then
             command="check"
         fi
+        coqchk_helper="$DIR/coqchk-as-coqc.sh"
         cat > "$file.new" <<EOF
 #!/usr/bin/env bash
 
@@ -129,7 +130,41 @@ progname="\$DIR/$file.orig"
 baseargs=("\$progname")
 args=("\$progname")
 command="${command}"
+coqchk_helper="${coqchk_helper}"
 ${extra_fragment}
+
+# If this is a checker invocation (coqchk / rocqchk / \`rocq check\`), hand off
+# to the coqchk-as-coqc helper, which turns the coqchk error into a coqc-style
+# error against a freshly-created \`Require <modules>.\` file and emits the
+# appropriate MINIMIZER_DEBUG metadata.  See
+# https://github.com/rocq-community/run-coq-bug-minimizer/issues/53
+if [ "\$command" == "check" ] && [ -f "\$coqchk_helper" ]; then
+    # For \`rocq check ...\`, drop the leading \`check\` subcommand.
+    chk_user_args=("\$@")
+    case "\$progname" in
+        *rocq.orig|*rocq|*rocq.byte) chk_user_args=("\${chk_user_args[@]:1}") ;;
+    esac
+    # Locate the (unwrapped) coqc-equivalent compiler used to build the tmp file.
+    coqc_cmd=()
+    for cand in "\$DIR/coqc.orig" "\$DIR/coqc"; do
+        if [ -x "\$cand" ]; then coqc_cmd=("\$cand"); break; fi
+    done
+    if [ "\${#coqc_cmd[@]}" -eq 0 ]; then
+        for cand in "\$DIR/rocq.orig" "\$DIR/rocq"; do
+            if [ -x "\$cand" ]; then coqc_cmd=("\$cand" c); break; fi
+        done
+    fi
+    # Locate the (unwrapped) standalone checker binary to run and record.
+    coqchk_cmd=()
+    for cand in "\$DIR/coqchk.orig" "\$DIR/coqchk" "\$DIR/rocqchk.orig" "\$DIR/rocqchk"; do
+        if [ -x "\$cand" ]; then coqchk_cmd=("\$cand"); break; fi
+    done
+    if [ "\${#coqchk_cmd[@]}" -eq 0 ]; then coqchk_cmd=("\$progname"); fi
+    if [ "\${#coqc_cmd[@]}" -gt 0 ]; then
+        exec "\$coqchk_helper" "\$(printf '%q ' "\${coqc_cmd[@]}")" "\$(printf '%q ' "\${coqchk_cmd[@]}")" -- "\${chk_user_args[@]}"
+    fi
+    # otherwise fall through to running the checker normally
+fi
 
 next_is_dir=no
 next_is_special=no

--- a/coqchk-as-coqc.sh
+++ b/coqchk-as-coqc.sh
@@ -1,0 +1,259 @@
+#!/usr/bin/env bash
+# coqchk-as-coqc.sh
+#
+# Wrapper that makes a coqchk / `rocq check` invocation look like a coqc
+# invocation to the bug minimizer.  It implements the four-step plan from
+# https://github.com/rocq-community/run-coq-bug-minimizer/issues/53:
+#
+#   1. collect the list of file modules that coqchk is asked to check;
+#   2. create a new .v file in /tmp that is just `Require <list of things>.`,
+#      named as a valid module name;
+#   3. emit the relevant MINIMIZER_DEBUG metadata as if coqc had been invoked
+#      on the tmp file, indicating which coqchk flags should be passed on to
+#      the minimizer (via a `${debug_prefix}.coqchk` side file);
+#   4. run coqchk as it was originally called, rewriting any errors in
+#      stdout/stderr to match the format of coqc errors, pointing at the last
+#      line of the tmp file.
+#
+# Usage:
+#   coqchk-as-coqc.sh <coqc-cmd> <coqchk-cmd> -- <original coqchk arguments...>
+#
+# where <coqc-cmd> and <coqchk-cmd> are `printf %q`-quoted command prefixes
+# (so that, e.g., `rocq c` can be passed as a single argument).  <coqc-cmd> is
+# the (unwrapped) compiler used to build the tmp file; <coqchk-cmd> is the
+# (unwrapped) checker that is actually run and recorded in the metadata.
+
+set -o pipefail
+
+coqc_q="$1"; shift || true
+coqchk_q="$1"; shift || true
+if [ "${1:-}" == "--" ]; then shift; fi
+
+eval "coqc_cmd=( ${coqc_q} )"
+eval "coqchk_cmd=( ${coqchk_q} )"
+orig_args=("$@")
+
+# If we have no checker command for some reason, fail loudly rather than
+# silently doing nothing.
+if [ "${#coqchk_cmd[@]}" -eq 0 ]; then
+    >&2 printf 'coqchk-as-coqc.sh: no coqchk command provided\n'
+    exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Step 1: parse the original coqchk arguments.
+#
+# coqchk's option grammar (see checker/coqchk_main.ml) is closed, so we can
+# classify every argument as one of:
+#   * load-path / kernel options that also make sense for coqc (-R, -Q,
+#     -coqlib, -bytecode-compiler, -impredicative-set, -indices-matter, -boot)
+#   * checker-only options that must be forwarded to the minimizer's coqchk
+#     (-silent, -admit, -norec)
+#   * purely diagnostic options we can drop (-o, -m, -d, -debug, -profile)
+#   * everything else, which coqchk treats as a target (a .vo file or a
+#     logical module name)
+# ---------------------------------------------------------------------------
+
+coqc_extra=()   # forwarded to the synthetic coqc invocation
+chk_fwd=()      # forwarded to the minimizer via --coqchk-args
+targets=()      # .vo files / module names to be Require'd
+R_dirs=()       # physical dirs of -R/-Q bindings (for .vo -> module mapping)
+R_logs=()       # logical names of -R/-Q bindings
+
+args=("${orig_args[@]}")
+while [ "${#args[@]}" -gt 0 ]; do
+    arg="${args[0]}"
+    case "${arg}" in
+        -R|-Q)
+            dir="${args[1]}"; log="${args[2]}"
+            coqc_extra+=("${arg}" "${dir}" "${log}")
+            R_dirs+=("${dir}"); R_logs+=("${log}")
+            args=("${args[@]:3}")
+            ;;
+        -coqlib|--coqlib|-bytecode-compiler|--bytecode-compiler)
+            coqc_extra+=("${arg}" "${args[1]}")
+            chk_fwd+=("${arg}" "${args[1]}")
+            args=("${args[@]:2}")
+            ;;
+        -impredicative-set|--impredicative-set|-indices-matter|--indices-matter|-boot|--boot)
+            coqc_extra+=("${arg}")
+            chk_fwd+=("${arg}")
+            args=("${args[@]:1}")
+            ;;
+        -admit|--admit|-norec|--norec)
+            chk_fwd+=("${arg}" "${args[1]}")
+            args=("${args[@]:2}")
+            ;;
+        -silent|--silent)
+            chk_fwd+=("${arg}")
+            args=("${args[@]:1}")
+            ;;
+        -o|--output-context|-m|--memory|-debug)
+            # purely diagnostic; not needed to reproduce the error
+            args=("${args[@]:1}")
+            ;;
+        -d|-profile)
+            # diagnostic, takes one argument
+            args=("${args[@]:2}")
+            ;;
+        -*)
+            # unknown flag; coqchk would have rejected it, so just drop it
+            args=("${args[@]:1}")
+            ;;
+        *)
+            targets+=("${arg}")
+            args=("${args[@]:1}")
+            ;;
+    esac
+done
+
+# Map a .vo file to a logical module name using the -R/-Q bindings, picking the
+# most specific (longest matching physical directory).
+vo_to_module() {
+    local vo="$1" abs adir log rel best="" bestlen=-1 i n
+    abs="$(readlink -f "${vo}" 2>/dev/null || printf '%s' "${vo}")"
+    n="${#R_dirs[@]}"
+    for ((i = 0; i < n; i++)); do
+        adir="$(readlink -f "${R_dirs[$i]}" 2>/dev/null || printf '%s' "${R_dirs[$i]}")"
+        log="${R_logs[$i]}"
+        case "${abs}" in
+            "${adir}"/*)
+                if [ "${#adir}" -gt "${bestlen}" ]; then
+                    bestlen="${#adir}"
+                    rel="${abs#"${adir}"/}"
+                    rel="${rel%.vo}"
+                    rel="${rel//\//.}"
+                    if [ -n "${log}" ]; then best="${log}.${rel}"; else best="${rel}"; fi
+                fi
+                ;;
+        esac
+    done
+    if [ -z "${best}" ]; then
+        best="$(basename "${vo%.vo}")"
+    fi
+    printf '%s' "${best}"
+}
+
+# ---------------------------------------------------------------------------
+# Step 4 (run first, so we can pick out the precise failing module): run
+# coqchk exactly as it was originally invoked, capturing its output.
+# ---------------------------------------------------------------------------
+out_file="$(mktemp --tmpdir=/tmp coqchk-as-coqc-out.XXXXXXXXXX)"
+err_file="$(mktemp --tmpdir=/tmp coqchk-as-coqc-err.XXXXXXXXXX)"
+"${coqchk_cmd[@]}" "${orig_args[@]}" >"${out_file}" 2>"${err_file}"
+chk_rc=$?
+
+# When coqchk is not run with -silent it prints "Checking library: <module>"
+# for each module just before checking it, so the last such line before a fatal
+# error names the offending module.  We prefer that precise module; otherwise
+# we fall back to Require'ing every requested target.
+failing_module="$(grep -h '^Checking library: ' "${out_file}" "${err_file}" 2>/dev/null | tail -1 | sed 's/^Checking library: //')"
+
+modules=()
+if [ -n "${failing_module}" ]; then
+    modules=("${failing_module}")
+else
+    for t in "${targets[@]}"; do
+        case "${t}" in
+            *.vo) modules+=("$(vo_to_module "${t}")") ;;
+            *)    modules+=("${t}") ;;
+        esac
+    done
+fi
+
+# Deduplicate modules, preserving order.
+deduped=()
+for m in "${modules[@]}"; do
+    skip=no
+    for d in "${deduped[@]}"; do
+        if [ "${d}" == "${m}" ]; then skip=yes; break; fi
+    done
+    [ "${skip}" == "no" ] && deduped+=("${m}")
+done
+modules=("${deduped[@]}")
+
+# If there is nothing to check (e.g. coqchk was invoked with no targets), there
+# is nothing useful for the minimizer to do; just reproduce coqchk's output
+# faithfully and exit.
+if [ "${#modules[@]}" -eq 0 ]; then
+    cat "${out_file}"
+    cat "${err_file}" >&2
+    rm -f "${out_file}" "${err_file}"
+    exit "${chk_rc}"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 2: create the tmp .v file `Require <modules>.`, named as a valid module.
+# ---------------------------------------------------------------------------
+tmp_base="$(mktemp --tmpdir=/tmp coqchkminimizerXXXXXXXXXX)"
+tmp_v="${tmp_base}.v"
+mv -f "${tmp_base}" "${tmp_v}"
+{
+    printf 'Require'
+    for m in "${modules[@]}"; do printf ' %s' "${m}"; done
+    printf '.\n'
+} > "${tmp_v}"
+abs_tmp_v="$(readlink -f "${tmp_v}")"
+
+# ---------------------------------------------------------------------------
+# Step 3: emit MINIMIZER_DEBUG metadata, pretending coqc was invoked on the
+# tmp file, and record the coqchk program + forwarded flags so that
+# run-script.sh can pass --chk / --coqchk / --coqchk-args to the minimizer.
+# ---------------------------------------------------------------------------
+debug_prefix="$(mktemp --tmpdir=/tmp tmp-coqbot-minimizer.XXXXXXXXXX)"
+printf "%s" "$0" > "${debug_prefix}"
+printf "%s" "${COQPATH}" > "${debug_prefix}.coqpath"
+printf "%s" "${OCAMLPATH}" > "${debug_prefix}.ocamlpath"
+printf "%s" "$(pwd)" > "${debug_prefix}.pwd"
+
+coqc_exec=("${coqc_cmd[@]}" "${coqc_extra[@]}" "${abs_tmp_v}")
+printf "%q " "${coqc_exec[@]}" > "${debug_prefix}.exec"
+"${coqc_cmd[@]}" --config > "${debug_prefix}.config" 2>&1 || true
+
+# The .coqchk side file records the (unwrapped) checker program followed by the
+# checker-only flags that should be forwarded to the minimizer's coqchk.
+printf "%q " "${coqchk_cmd[@]}" "${chk_fwd[@]}" > "${debug_prefix}.coqchk"
+
+build_minimizer_debug_msg() {
+    printf "MINIMIZER_DEBUG_EXTRA: coqc: %s\n" "$0"
+    printf "MINIMIZER_DEBUG_EXTRA: original invocation: %s\n" "$(printf "%q " "${coqchk_cmd[@]}" "${orig_args[@]}")"
+    printf "MINIMIZER_DEBUG_EXTRA: new invocation: %s\n" "$(printf "%q " "${coqc_exec[@]}")"
+    printf "MINIMIZER_DEBUG_EXTRA: coqpath: %s\n" "${COQPATH}"
+    printf "MINIMIZER_DEBUG_EXTRA: ocamlpath: %s\n" "${OCAMLPATH}"
+    printf "MINIMIZER_DEBUG_EXTRA: pwd: PWD=%s\n" "$(pwd)"
+    printf "MINIMIZER_DEBUG_EXTRA: coqchk: %s\n" "$(printf "%q " "${coqchk_cmd[@]}" "${chk_fwd[@]}")"
+    printf "MINIMIZER_DEBUG_EXTRA: coqlib: %s\n" "$(grep 'COQLIB\|ROCQLIB' "${debug_prefix}.config" | sed 's/COQLIB=//g; s/ROCQLIB=//g')"
+    # the important lines, consumed by run-script.sh
+    printf "MINIMIZER_DEBUG: info: %s\n" "${debug_prefix}"
+    printf "MINIMIZER_DEBUG: files: %s\n" " ${abs_tmp_v} ${abs_tmp_v}"
+    printf "MINIMIZER_DEBUG: coqchk: %s\n" "${debug_prefix}.coqchk"
+}
+
+>&2 printf '%s\n' "$(build_minimizer_debug_msg)"
+
+# ---------------------------------------------------------------------------
+# Step 4 (continued): re-emit coqchk's output, inserting a fake coqc error
+# location pointing at the last line of the tmp file before every fatal error.
+# ---------------------------------------------------------------------------
+line_count="$(wc -l < "${tmp_v}" | tr -d ' ')"
+[ -z "${line_count}" ] && line_count=1
+[ "${line_count}" -lt 1 ] && line_count=1
+
+process_output() {
+    local v_file="$1" lc="$2" line
+    while IFS= read -r line || [ -n "${line}" ]; do
+        case "${line}" in
+            "Fatal Error:"*|"Fatal error:"*)
+                printf 'File "%s", line %s, characters 0-0:\n' "${v_file}" "${lc}"
+                printf 'Error:\n'
+                ;;
+        esac
+        printf '%s\n' "${line}"
+    done
+}
+
+process_output "${abs_tmp_v}" "${line_count}" < "${out_file}"
+process_output "${abs_tmp_v}" "${line_count}" < "${err_file}" >&2
+
+rm -f "${out_file}" "${err_file}"
+exit "${chk_rc}"

--- a/run-script.sh
+++ b/run-script.sh
@@ -196,6 +196,24 @@ EXEC_PWD="$(cat "${DEBUG_PREFIX}.pwd" | sed "s,${COQ_CI_BASE_BUILD_DIR}/,${CI_BA
 COQLIB="$(cat "${DEBUG_PREFIX}.config" | sed "s,${COQ_CI_BASE_BUILD_DIR}/,${CI_BASE_BUILD_DIR}/coq-failing/,g" | grep --max-count=1 '^COQLIB=\|^ROCQLIB=' | sed 's/^COQLIB=//g; s/^ROCQLIB=//g')"
 FAILING_OCAMLPATH="$(cat "${DEBUG_PREFIX}.ocamlpath" | sed "s,${COQ_CI_BASE_BUILD_DIR}/,${CI_BASE_BUILD_DIR}/coq-failing/,g")"
 
+# If this failure came from a checker (coqchk / rocqchk / `rocq check`)
+# invocation, the wrapper records the (unwrapped) checker program and the
+# checker-only flags to forward to the minimizer in a `.coqchk` side file; see
+# coqchk-as-coqc.sh.  When present, we pass --chk / --coqchk / --coqchk-args.
+COQCHK_INFO_FILE="${DEBUG_PREFIX}.coqchk"
+HAVE_COQCHK=no
+FAILING_COQCHK=""
+PASSING_COQCHK=""
+COQCHK_FWD_ARGS=()
+if [ -f "${COQCHK_INFO_FILE}" ]; then
+    HAVE_COQCHK=yes
+    mapfile -t COQCHK_TOKENS < <(bash -c "split_args_to_lines $(cat "${COQCHK_INFO_FILE}")")
+    COQCHK_RAW_PROG="${COQCHK_TOKENS[0]}"
+    COQCHK_FWD_ARGS=("${COQCHK_TOKENS[@]:1}")
+    FAILING_COQCHK="$(printf "%s" "${COQCHK_RAW_PROG}" | sed "s,${COQ_CI_BASE_BUILD_DIR}/,${CI_BASE_BUILD_DIR}/coq-failing/,g")"
+    PASSING_COQCHK="$(printf "%s" "${FAILING_COQCHK}" | sed "s,\(${CI_BASE_BUILD_DIR}\)/coq-failing/,\\1/coq-passing/,g")"
+fi
+
 FAILING_COQPATH="${COQPATH}"
 FAILING_COQLIB="${COQLIB}"
 # some people (like Iris) like to use `coqtop -batch -lv` or similar to process a .v file, so we replace coqtop with coqc
@@ -240,7 +258,14 @@ mkdir -p "$(dirname "${TMP_LOG}")"
 
 cd "$(dirname "${BUG_FILE}")"
 
-for VAR in FAILING_COQC FAILING_COQTOP PASSING_COQC PASSING_COQ_MAKEFILE PASSING_COQDEP; do
+CHECK_VARS=(FAILING_COQC FAILING_COQTOP PASSING_COQC PASSING_COQ_MAKEFILE PASSING_COQDEP)
+if [ "${HAVE_COQCHK}" == "yes" ]; then
+    CHECK_VARS+=(FAILING_COQCHK)
+    if [ "${PASSING_COQC}" != "${FAILING_COQC}" ]; then
+        CHECK_VARS+=(PASSING_COQCHK)
+    fi
+fi
+for VAR in "${CHECK_VARS[@]}"; do
     if [ ! -x "${!VAR}" ]; then
         printf "Error: Could not find %s ('%s')\n" "${VAR}" "${!VAR}" | tee -a "${BUG_LOG}" "${VERBOSE_BUG_LOG}" >&2
         printf "Files in '%s':\n" "$(dirname ${!VAR})" | tee -a "${BUG_LOG}" "${VERBOSE_BUG_LOG}" >&2
@@ -260,12 +285,22 @@ else
     args+=("${ABS_FILE}" "${BUG_FILE}" "${TMP_FILE}" --error-log="${BUILD_LOG}" --temp-file-log="${TMP_LOG}")
 fi
 args+=(--no-deps --ignore-coq-prog-args --inline-user-contrib --coqc="${FAILING_COQC}" --coqtop="${FAILING_COQTOP}" --coq_makefile="${PASSING_COQ_MAKEFILE}" --coqdep "${PASSING_COQDEP}" --base-dir="${FAILING_EXEC_PWD}" --ocamlpath="${FAILING_OCAMLPATH}" -Q "${BUG_TMP_DIR}" Top --verbose-include-failure-warning --verbose-include-failure-warning-prefix "::warning::" --verbose-include-failure-warning-newline "%0A")
+if [ "${HAVE_COQCHK}" == "yes" ]; then
+    # the failure came from the checker, so have the minimizer run coqchk too
+    args+=(--chk --coqchk="${FAILING_COQCHK}")
+    if [ "${#COQCHK_FWD_ARGS[@]}" -gt 0 ]; then
+        args+=(--coqchk-args=" ${COQCHK_FWD_ARGS[*]}")
+    fi
+fi
 printf '%s\n' "$(printf 'appending failing args: '; printf '%q ' "${FAILING_ARGS[@]}")"
 args+=("${FAILING_ARGS[@]}")
 if [ "${PASSING_COQC}" != "${FAILING_COQC}" ]; then
     # are running with two versions
     mkdir -p "${CI_BASE_BUILD_DIR}/coq-passing/_build_ci/"
     args+=(--passing-coqc="${PASSING_COQC}" --passing-coqtop="${PASSING_COQTOP}" --passing-base-dir="${EXEC_PWD}" --passing-ocamlpath="${PASSING_OCAMLPATH}")
+    if [ "${HAVE_COQCHK}" == "yes" ]; then
+        args+=(--passing-coqchk="${PASSING_COQCHK}")
+    fi
     printf '%s\n' "$(printf 'appending passing args: '; printf '%q ' "${FAILING_ARGS[@]}")"
     args+=("${PASSING_ARGS[@]}")
 fi

--- a/test/test-coqchk-wrapper.sh
+++ b/test/test-coqchk-wrapper.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Tests for the coqchk wrapping logic in coqbot-config.sh + coqchk-as-coqc.sh.
+#
+# These tests stand up fake `coqc`/`coqchk` binaries, wrap them exactly the way
+# the minimizer runner does (via wrap_file from coqbot-config.sh), run a checker
+# invocation, and assert that:
+#   * a `Require <modules>.` tmp file is created with the right module names;
+#   * MINIMIZER_DEBUG metadata is emitted pointing at that tmp file;
+#   * the synthetic coqc invocation and the `.coqchk` side file are recorded;
+#   * coqchk "Fatal Error:" output is rewritten into coqc-style errors.
+#
+# The tests use stubs only, so they need nothing more than bash + coreutils.
+
+REPO_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." >/dev/null 2>&1 && pwd )"
+
+# Failures are accumulated in a file so that assertions made inside subshells
+# still count towards the overall result.
+FAILURES_FILE="$(mktemp)"
+
+pass() { printf 'ok   [%s]: %s\n' "${testname}" "$1"; }
+fail() {
+    printf 'FAIL [%s]: %s\n' "${testname}" "$1" >&2
+    printf 'x\n' >> "${FAILURES_FILE}"
+}
+assert_contains() {
+    # assert_contains <haystack-file> <needle> <description>
+    if [ -f "$1" ] && grep -qF -- "$2" "$1"; then
+        pass "$3"
+    else
+        fail "$3"
+        printf '  --- looked for: %s\n  --- in %s:\n' "$2" "$1" >&2
+        [ -f "$1" ] && sed 's/^/  | /' "$1" >&2
+    fi
+}
+assert_not_contains() {
+    if [ -f "$1" ] && grep -qF -- "$2" "$1"; then
+        fail "$3"
+    else
+        pass "$3"
+    fi
+}
+
+# Create a sandbox bin dir with fake coqc/coqchk binaries.
+#   $1 = module name (matching a target token) that coqchk should fail on
+#        (empty for "fail on every target")
+make_sandbox() {
+    local bad_module="$1"
+    local bindir
+    bindir="$(mktemp -d)"
+
+    cat > "${bindir}/coqc" <<'COQC'
+#!/usr/bin/env bash
+# fake coqc: understands --config and "compiles" a .v into a .vo
+if [ "$1" == "--config" ]; then
+    echo "COQLIB=/fake/coqlib"
+    echo "COQCORELIB=/fake/coq-core"
+    exit 0
+fi
+vfile=""
+for a in "$@"; do
+    case "$a" in
+        *.v) vfile="$a" ;;
+    esac
+done
+[ -n "$vfile" ] && : > "${vfile%.v}.vo"
+exit 0
+COQC
+    chmod +x "${bindir}/coqc"
+
+    cat > "${bindir}/coqchk" <<COQCHK
+#!/usr/bin/env bash
+# fake coqchk: prints "Checking library:" lines (unless -silent) and fails on a
+# designated bad module (or on every target if none is designated).
+bad_module="${bad_module}"
+silent=no
+targets=()
+skipnext=0
+for a in "\$@"; do
+    if [ "\${skipnext}" -gt 0 ]; then skipnext=\$((skipnext - 1)); continue; fi
+    case "\$a" in
+        -silent) silent=yes ;;
+        -R|-Q) skipnext=2 ;;
+        -coqlib|-bytecode-compiler|-admit|-norec|-d|-profile) skipnext=1 ;;
+        -*) ;;
+        *) targets+=("\$a") ;;
+    esac
+done
+rc=0
+for t in "\${targets[@]}"; do
+    [ "\${silent}" == "no" ] && echo "Checking library: \${t}"
+    if [ -z "\${bad_module}" ] || [ "\${t}" == "\${bad_module}" ]; then
+        echo "Fatal Error: Type error: IllFormedRecBody" >&2
+        rc=1
+    fi
+done
+exit \${rc}
+COQCHK
+    chmod +x "${bindir}/coqchk"
+
+    printf '%s' "${bindir}"
+}
+
+wrap_in() {
+    # wrap_in <bindir> <file>...; wraps the given binaries via wrap_file
+    local bindir="$1"; shift
+    (
+        cd "${bindir}" || exit 1
+        set +u
+        # shellcheck disable=SC1091
+        source "${REPO_DIR}/coqbot-config.sh" >/dev/null 2>&1
+        for f in "$@"; do wrap_file "$f"; done
+    )
+}
+
+# Extract the metadata debug-prefix from a captured log.
+debug_prefix_from() {
+    grep -o 'MINIMIZER_DEBUG: info: .*' "$1" | tail -1 | sed 's/^MINIMIZER_DEBUG: info: //'
+}
+# Extract the synthetic tmp .v path from a recorded .exec metadata file.
+tmpv_from_exec() {
+    tr ' ' '\n' < "$1" | grep '\.v$' | tail -1
+}
+
+# ---------------------------------------------------------------------------
+testname="vo-target with -silent (CoqMakefile-style validate)"
+# ---------------------------------------------------------------------------
+{
+    bindir="$(make_sandbox "")"  # no Checking-library trace because -silent
+    libdir="$(mktemp -d)"
+    mkdir -p "${libdir}/PrimalityTest"
+    : > "${libdir}/PrimalityTest/Root.vo"
+    wrap_in "${bindir}" coqc coqchk
+
+    log="$(mktemp)"
+    ( cd "${libdir}" && "${bindir}/coqchk" -silent -o -R "${libdir}" Coqprime "${libdir}/PrimalityTest/Root.vo" ) >"${log}" 2>&1
+    rc=$?
+
+    assert_contains "${log}" 'MINIMIZER_DEBUG: files:' "emits files metadata line"
+    assert_contains "${log}" 'MINIMIZER_DEBUG: coqchk:' "emits coqchk metadata line"
+    assert_contains "${log}" 'File "' "rewrites error into coqc File location"
+    assert_contains "${log}" 'Error:' "emits a coqc-style Error: line"
+    assert_contains "${log}" 'Fatal Error: Type error: IllFormedRecBody' "preserves the fatal error text"
+
+    dp="$(debug_prefix_from "${log}")"
+    tmpv="$(tmpv_from_exec "${dp}.exec")"
+    assert_contains "${tmpv}" 'Require Coqprime.PrimalityTest.Root.' "tmp file requires the .vo-derived module"
+    assert_contains "${dp}.coqchk" '-silent' "forwards -silent to the minimizer coqchk"
+    assert_contains "${dp}.exec" "${bindir}/coqc" "synthetic invocation uses coqc"
+    assert_contains "${dp}.config" 'COQLIB=' "records coqc --config output"
+
+    if [ "${rc}" -ne 0 ]; then pass "propagates non-zero exit"; else fail "checker invocation should propagate non-zero exit"; fi
+}
+
+# ---------------------------------------------------------------------------
+testname="module-name target without -silent (precise failing module)"
+# ---------------------------------------------------------------------------
+{
+    bad="Coqprime.PrimalityTest.Root"
+    bindir="$(make_sandbox "${bad}")"
+    libdir="$(mktemp -d)"
+    wrap_in "${bindir}" coqc coqchk
+
+    log="$(mktemp)"
+    ( cd "${libdir}" && "${bindir}/coqchk" -R "${libdir}" Coqprime Coqprime.List.ListAux Coqprime.PrimalityTest.Root ) >"${log}" 2>&1
+
+    dp="$(debug_prefix_from "${log}")"
+    tmpv="$(tmpv_from_exec "${dp}.exec")"
+    assert_contains "${tmpv}" 'Require Coqprime.PrimalityTest.Root.' "tmp file requires only the failing module"
+    assert_not_contains "${tmpv}" 'ListAux' "drops non-failing modules"
+}
+
+# ---------------------------------------------------------------------------
+testname="coqc invocation is left untouched (regression)"
+# ---------------------------------------------------------------------------
+{
+    bindir="$(make_sandbox "")"
+    libdir="$(mktemp -d)"
+    printf 'Definition x := 0.\n' > "${libdir}/A.v"
+    wrap_in "${bindir}" coqc coqchk
+
+    log="$(mktemp)"
+    ( cd "${libdir}" && "${bindir}/coqc" -R "${libdir}" Top "${libdir}/A.v" ) >"${log}" 2>&1
+    rc=$?
+
+    # coqc wrapping must still emit its own debug info and must NOT emit coqchk
+    # metadata or invoke the checker helper.
+    assert_contains "${log}" 'MINIMIZER_DEBUG: files:' "coqc still emits files metadata"
+    assert_not_contains "${log}" 'MINIMIZER_DEBUG: coqchk:' "coqc does not emit coqchk metadata"
+    if [ "${rc}" -eq 0 ] && [ -f "${libdir}/A.vo" ]; then pass "coqc compiles normally"; else fail "coqc should compile normally"; fi
+}
+
+# ---------------------------------------------------------------------------
+testname="rocq check (subcommand dispatch)"
+# ---------------------------------------------------------------------------
+{
+    bindir="$(make_sandbox "")"
+    # a `rocq` dispatcher: `rocq c` compiles, `rocq check` checks
+    cat > "${bindir}/rocq" <<ROCQ
+#!/usr/bin/env bash
+sub="\$1"; shift
+case "\${sub}" in
+    c|compile) exec "${bindir}/coqc" "\$@" ;;
+    check)     exec "${bindir}/coqchk" "\$@" ;;
+    *)         exit 0 ;;
+esac
+ROCQ
+    chmod +x "${bindir}/rocq"
+    # provide a standalone checker binary for the metadata to reference
+    cp "${bindir}/coqchk" "${bindir}/rocqchk"
+    libdir="$(mktemp -d)"
+    mkdir -p "${libdir}/PrimalityTest"
+    : > "${libdir}/PrimalityTest/Root.vo"
+    wrap_in "${bindir}" coqc rocq rocqchk
+
+    log="$(mktemp)"
+    ( cd "${libdir}" && "${bindir}/rocq" check -silent -R "${libdir}" Coqprime "${libdir}/PrimalityTest/Root.vo" ) >"${log}" 2>&1
+
+    assert_contains "${log}" 'MINIMIZER_DEBUG: coqchk:' "rocq check emits coqchk metadata"
+    assert_contains "${log}" 'File "' "rocq check rewrites error into coqc File location"
+    dp="$(debug_prefix_from "${log}")"
+    if [ -n "${dp}" ]; then
+        tmpv="$(tmpv_from_exec "${dp}.exec")"
+        assert_contains "${tmpv}" 'Require Coqprime.PrimalityTest.Root.' "rocq check derives the module from the .vo"
+    else
+        fail "rocq check should emit a debug prefix"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+nfail="$(wc -l < "${FAILURES_FILE}" | tr -d ' ')"
+rm -f "${FAILURES_FILE}"
+if [ "${nfail}" -eq 0 ]; then
+    printf '\nAll coqchk wrapper tests passed.\n'
+    exit 0
+else
+    printf '\n%s coqchk wrapper test(s) failed.\n' "${nfail}"
+    exit 1
+fi


### PR DESCRIPTION
Implements the four-step plan from rocq-community/run-coq-bug-minimizer#53 so that failures from `coqchk` / `rocqchk` / `rocq check` (e.g. the `IllFormedRecBody` regression in rocq-prover/rocq#22125) get minimized instead of being dropped on the floor.

`coq-tools` already grew coqchk support (JasonGross/coq-tools#403, JasonGross/coq-tools#404), where minimization works by running `coqchk` after `coqc` and inserting a fake location into the checker output pointing at the end of the `.v` file. This PR wires that up to the runner.

## What changed

### `coqchk-as-coqc.sh` (new)
When a checker is invoked, the wrapper now hands off to this helper, which:
1. **collects the modules being checked** — from the `-R`/`-Q` load path applied to the `.vo` targets, or from coqchk's own `Checking library: <module>` trace when it isn't run with `-silent`;
2. **creates a tmp `.v` file** in `/tmp`, named as a valid module, containing `Require <modules>.`;
3. **emits `MINIMIZER_DEBUG` metadata** as if `coqc` had been called on that tmp file, plus a `.coqchk` side file that records the (unwrapped) checker program and the checker-only flags to forward to the minimizer;
4. **runs coqchk as originally invoked**, rewriting `Fatal Error:` output into a coqc-style `File "...", line N, characters 0-0:` / `Error:` location pointing at the last line of the tmp file (the exact format `coq-tools` itself produces, so error detection stays consistent).

The precise failing module is preferred when available; otherwise every requested target is `Require`d and the minimizer narrows it down.

### `coqbot-config.sh`
The generated wrapper delegates checker invocations (`coqchk`, `rocqchk`, `rocq check`) to the helper. Also fixes an inverted `command="check"` test from the initial WIP commit so that plain `coqc` keeps its normal `-o <file>` argument handling and only the checker commands are treated as checks.

### `run-script.sh`
When the failing invocation carries `.coqchk` metadata, the runner passes `--chk --coqchk=<checker> --coqchk-args="..."` (and `--passing-coqchk` for two-version runs) to `find-bug.py`, and includes the checker binary in the executability sanity checks.

### Tests — `test/test-coqchk-wrapper.sh` + `.github/workflows/test-wrapper.yml`
Stub-based unit tests for the wrapper that need nothing more than bash + coreutils (no Coq/Rocq install), covering:
- a `.vo` target with `-silent` (the `CoqMakefile` `validate` shape) → module derived from the load path, metadata + rewritten error emitted;
- a module-name target without `-silent` → only the precise failing module is `Require`d;
- a plain `coqc` invocation is left untouched (regression guard);
- `rocq check` subcommand dispatch.

All 18 assertions pass locally.

These changes are contained to the runner repo.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Uy4PAeARWFGNgmukKQBLFQ)_